### PR TITLE
Checkmarx AI Remediation - CVE-2022-24785

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "ejs": "3.1.10",
         "marked": "0.3.5",
-        "moment": "2.15.1"
+        "moment": "2.29.4"
       }
     },
     "node_modules/async": {
@@ -90,9 +90,9 @@
       }
     },
     "node_modules/moment": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.1.tgz",
-      "integrity": "sha512-VRuqlq9ET3eUjWkqgZtUegkYF664TRWaxmgwlHxboe653wv4stNaVKDufNfCDcGFu1EA2Bm26bD0NWLaFMHfvA==",
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
       "engines": {
         "node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "ejs": "1.0.0",
     "marked": "0.3.5",
-    "moment": "2.15.1",
+    "moment": "2.29.4",
     "underscore": "^1.8.3"
   },
   "license": "Apache-2.0"


### PR DESCRIPTION
![Logo](https://cdn.ast.checkmarx.net/integrations/logo/Checkmarx.png)
**Checkmarx One – Remediation**

---

## CVE-2022-24785 · <img src="https://cdn.ast.checkmarx.net/integrations/severity/High.png" width="18" height="18" /> High · <img src="https://cdn.ast.checkmarx.net/integrations/triage/false-positive.png" width="18" height="18" /> Suspected False Positive

Triage context: <img src="https://cdn.ast.checkmarx.net/integrations/triage/not-reachable.png" width="16" height="16" /> **Not Reachable** · <img src="https://cdn.ast.checkmarx.net/integrations/triage/not-exploitable.png" width="16" height="16" /> **Not Exploitable**

Fix path traversal vulnerability in moment.js

**What is the issue?**
This remediation addresses CVE-2022-24785, a HIGH severity path traversal vulnerability in moment.js versions 1.0.1 through 2.29.1. The vulnerability allows attackers to access files outside the intended directory structure by injecting path traversal sequences (like `../`) into locale parameters. This could lead to unauthorized file access and information disclosure of sensitive data.

**Why should it be fixed?**
This vulnerability must be fixed because it exposes the application to path traversal attacks that could allow attackers to read sensitive files from the server filesystem, leading to unauthorized access and information disclosure. Even though moment.js is not actively used in the current codebase, the vulnerable dependency poses a security risk and violates security best practices.

**How should it be fixed?**
Upgrade moment.js from vulnerable version 2.15.1 to secure version 2.29.4 in package.json. Update package-lock.json to reflect the new version and integrity hash for moment.js 2.29.4. The secure version includes patches that properly validate and sanitize locale strings before processing them, preventing path traversal attacks.



---
Use @Checkmarx to interact with Checkmarx PR Assistant. 
*Examples:*
`@Checkmarx how are you able to help me?`
`@Checkmarx rescan this PR`
